### PR TITLE
Unify the way dependencies are versioned.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile "com.android.support:appcompat-v7:$supportLibVersion"
     compile "com.android.support:design:$supportLibVersion"
 
-    compile 'com.jakewharton:butterknife:8.5.1'
+    compile "com.jakewharton:butterknife:$butterKnifeVersion"
 
     compile project(':library')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ ext {
     targetSdkVersion = compileSdkVersion
 
     supportLibVersion = '26.1.0'
+    iconHandlerVersion = 'v2.0.0'
+    butterKnifeVersion = '8.5.1'
 }
 
 task clean(type: Delete) {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     compile "com.android.support:appcompat-v7:$supportLibVersion"
     compile "com.android.support:cardview-v7:$supportLibVersion"
-    compile 'com.github.jrvansuita:IconHandler:+'
+    compile "com.github.jrvansuita:IconHandler:$iconHandlerVersion"
 }


### PR DESCRIPTION
The plus in `com.github.jrvansuita:IconHandler:+` makes it the library inconvenient to use when you have no internet (I code a lot on the underground).