### PR TITLE
Use screen_name instead of user_id

### DIFF
--- a/library/src/main/res/values/consts.xml
+++ b/library/src/main/res/values/consts.xml
@@ -15,7 +15,7 @@
     <string name="id_facebook_app">com.facebook.katana</string>
 
     <string name="url_twitter_website">https://twitter.com/%s</string>
-    <string name="uri_twitter_app">twitter://user?user_id=%s</string>
+    <string name="uri_twitter_app">twitter://user?screen_name=%s</string>
     <string name="id_twitter_app">com.twitter.android</string>
 
     <string name="url_google_plus_website">https://plus.google.com/%s</string>


### PR DESCRIPTION
Potential fix for issue #63 

I will be using @SpaceLaunchNow (user_id= 841696172259606528) as the example account. The code as is first tries the URI - if a package is not available to handle the twitter:// URI then it falls back to the web URL.

As is the URI works ONLY with the user_id - however the web url ONLY works with the screen name.

Relevant [intent logic](https://github.com/jrvansuita/MaterialAbout/blob/master/library/src/main/java/com/vansuita/materialabout/util/IntentUtil.java#L93-L100) here.
```Java
	public Intent openTwitter (String user) {
		try {
			tryPackage(R.string.id_twitter_app);
			return intent(R.string.uri_twitter_app, user);
		} catch (Exception e) {
			return intent(R.string.url_twitter_website, user);
		}
	}
```


Example A - URI doesn’t work but weblink does:
twitter://user?user_id= SpaceLaunchNow
https://twitter.com/SpaceLaunchNow

Example B - URI works but weblink doesnt:
twitter://user?user_id=841696172259606528
https://twitter.com/841696172259606528

The obvious solution is to use just the screen_name or just the user_id for the URI and fallback link. From what I can see the web url only accepts screen names so changing the URI to screen_name makes more sense.