### PR TITLE
Fix issue #74. 

### DIFF
--- a/library/src/main/java/com/vansuita/materialabout/views/AutoFitGridLayout.java
+++ b/library/src/main/java/com/vansuita/materialabout/views/AutoFitGridLayout.java
@@ -79,11 +79,8 @@ public final class AutoFitGridLayout extends ViewGroup {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         refreshNotGoneChildList();
-        if (childWidth <= 0) {
-            final int parentWidth = MeasureSpec.getSize(widthMeasureSpec);
-            childWidth = (int) (
-                    (parentWidth - (columnCount - 1) * horizontalSpace * 1.0f) / columnCount + 0.5f);
-        }
+        int parentWidth = MeasureSpec.getSize(widthMeasureSpec);
+        childWidth = (int) ((parentWidth - (columnCount - 1) * horizontalSpace * 1.0f) / columnCount + 0.5f);
         int childCount = notGoneViewList.size();
         int line = childCount % columnCount == 0 ? childCount / columnCount
                 : childCount / columnCount + 1;


### PR DESCRIPTION
The "onMeasure" method is called multiple times with different values for the widthMeasureSpec parameter. But the value for childWidth was calculated only in the first method call. Therefore, the width was calculated incorrectly.